### PR TITLE
Improve `arrays_equal` performance by eliding bounds check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,13 @@ pub fn arrays_equal(a: &[u8], b: &[u8]) -> Mask {
 
     let mut x: u8 = 0;
 
-    for i in 0 .. a.len() {
+    // These useless slices make the optimizer elide the bounds checks.
+    // See the comment in clone_from_slice() added on Rust commit 6a7bc47.
+    let len = a.len();
+    let a = &a[..len];
+    let b = &b[..len];
+
+    for i in 0 .. len {
         x |= a[i] ^ b[i];
     }
     bytes_equal(x, 0)


### PR DESCRIPTION
Hi!

I've copied Cesar Eduardo Barros' code from the [`constant_time_eq` crate](https://github.com/cesarb/constant_time_eq) (CC0).

It basically gives the compiler a hint that bounds checking is not necessary when iterating over the elements of the arrays. The speedup is noticeable, e.g. [here are some benches:](https://github.com/mp4096/rust-constant-time-comp-bench)

```
$ cargo bench

running 6 tests
test tests::bench_functional_generic                       ... bench:     107,932 ns/iter (+/- 1,759)
test tests::bench_functional_specialised                   ... bench:       4,568 ns/iter (+/- 99)
test tests::bench_imperative_generic                       ... bench:     107,690 ns/iter (+/- 1,671)
test tests::bench_imperative_generic_no_bound_checking     ... bench:      73,462 ns/iter (+/- 930)
test tests::bench_imperative_specialised                   ... bench:      72,017 ns/iter (+/- 1,159)
test tests::bench_imperative_specialised_no_bound_checking ... bench:       4,565 ns/iter (+/- 66)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out
```
