### PR TITLE
Use no_std unless the "std" feature is present

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@
 
 //! Pure-Rust traits and utilities for constant-time cryptographic implementations.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "std")]
 extern crate core;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This crate was 99% of the way there for no_std support. Here's the last 1%.